### PR TITLE
Fixed hdf5; check for number of channels

### DIFF
--- a/ParseInput.py
+++ b/ParseInput.py
@@ -38,7 +38,7 @@ def ParseInputDataExtract():
    #Create a dictionary object to pass to the next function
    dict = {'masks': args.masks, 'image': args.image,\
     'channel_names': args.channel_names,'output':args.output,
-    'intensity_props': set(args.intensity_props if args.intensity_props is not None else []).union(["mean_intensity"]),
+    'intensity_props': set(args.intensity_props if args.intensity_props is not None else []).union(["intensity_mean"]),
     'mask_props': args.mask_props,
    }
    #Print the dictionary object

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -82,31 +82,19 @@ def PrepareData(image,z):
 
     #Check to see if image tif(f)
     if image_path.suffix == '.tiff' or image_path.suffix == '.tif' or image_path.suffix == '.btf':
-        #Check to see if the image is ome.tif(f)
-        if  image.endswith(('.ome.tif','.ome.tiff')):
-            #Read the image
-            image_loaded_z = skimage.io.imread(image,img_num=z,plugin='tifffile')
-            #print('OME TIF(F) found')
-        else:
-            #Read the image
-            image_loaded_z = skimage.io.imread(image,img_num=z,plugin='tifffile')
-            #print('TIF(F) found')
-            # Remove extra axis
-            #image_loaded = image_loaded.reshape((image_loaded.shape[1],image_loaded.shape[3],image_loaded.shape[4]))
+        image_loaded_z = skimage.io.imread(image,img_num=z,plugin='tifffile')
 
     #Check to see if image is hdf5
     elif image_path.suffix == '.h5' or image_path.suffix == '.hdf5':
         #Read the image
-        f = h5py.File(image,'r+')
+        f = h5py.File(image,'r')
         #Get the dataset name from the h5 file
         dat_name = list(f.keys())[0]
-        ###If the hdf5 is exported from ilastik fiji plugin, the dat_name will be 'data'
-        #Get the image data
-        image_loaded = np.array(f[dat_name])
-        #Remove the first axis (ilastik convention)
-        image_loaded = image_loaded.reshape((image_loaded.shape[1],image_loaded.shape[2],image_loaded.shape[3]))
-        ###If the hdf5 is exported from ilastik fiji plugin, the order will need to be
-        ###switched as above --> z_stack = np.swapaxes(z_stack,0,2) --> z_stack = np.swapaxes(z_stack,0,1)
+        #Retrieve the z^th channel
+        image_loaded_z = f[dat_name][0,:,:,z]
+
+    else:
+        raise Exception('mcquant currently supports [OME]TIFF and HDF5 formats only')
 
     #Return the objects
     return image_loaded_z

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -81,7 +81,10 @@ def n_channels(image):
 
     if image_path.suffix in ['.tiff', '.tif', '.btf']:
         s = tifffile.TiffFile(image).series[0]
-        return s.shape[0] if len(s.shape) > 2 else 1	# Handle (w,h) cases
+        ndim = len(s.shape)
+        if ndim == 2: return 1
+        elif ndim == 3: return min(s.shape)
+        else: raise Exception('mcquant supports only 2D/3D images.')
 
     elif image_path.suffix in ['.h5', '.hdf5']:
         f = h5py.File(image, 'r')
@@ -99,7 +102,7 @@ def PrepareData(image,z):
 
     #Check to see if image tif(f)
     if image_path.suffix in ['.tiff', '.tif', '.btf']:
-        image_loaded_z = skimage.io.imread(image,img_num=z,plugin='tifffile')
+        image_loaded_z = tifffile.imread(image, key=z)
 
     #Check to see if image is hdf5
     elif image_path.suffix in ['.h5', '.hdf5']:

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 import os
 import skimage.measure as measure
+import tifffile
 
 from pathlib import Path
 
@@ -73,6 +74,19 @@ def MaskIDs(mask, mask_props=None):
 
     return dat
 
+def n_channels(image):
+    """Returns the number of channel in the input image. Supports [OME]TIFF and HDF5."""
+
+    image_path = Path(image)
+
+    if image_path.suffix in ['.tiff', '.tif', '.btf']:
+        s = tifffile.TiffFile(image).series[0]
+        return s.shape[0] if len(s.shape) > 2 else 1	# Handle (w,h) cases
+
+    elif image_path.suffix in ['.h5', '.hdf5']:
+        f = h5py.File(image, 'r')
+        dat_name = list(f.keys())[0]
+        return f[dat_name].shape[3]
 
 def PrepareData(image,z):
     """Function for preparing input for maskzstack function. Connecting function
@@ -81,11 +95,11 @@ def PrepareData(image,z):
     image_path = Path(image)
 
     #Check to see if image tif(f)
-    if image_path.suffix == '.tiff' or image_path.suffix == '.tif' or image_path.suffix == '.btf':
+    if image_path.suffix in ['.tiff', '.tif', '.btf']:
         image_loaded_z = skimage.io.imread(image,img_num=z,plugin='tifffile')
 
     #Check to see if image is hdf5
-    elif image_path.suffix == '.h5' or image_path.suffix == '.hdf5':
+    elif image_path.suffix in ['.h5', '.hdf5']:
         #Read the image
         f = h5py.File(image,'r')
         #Get the dataset name from the h5 file

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -19,10 +19,10 @@ def gini_index(mask, intensity):
     cumx = np.cumsum(sorted_x, dtype=float)
     return (n + 1 - 2 * np.sum(cumx) / cumx[-1]) / n
 
-def median_intensity(mask, intensity):
+def intensity_median(mask, intensity):
     return np.median(intensity[mask])
 
-def MaskChannel(mask_loaded, image_loaded_z, intensity_props=["mean_intensity"]):
+def MaskChannel(mask_loaded, image_loaded_z, intensity_props=["intensity_mean"]):
     """Function for quantifying a single channel image
 
     Returns a table with CellID according to the mask and the mean pixel intensity
@@ -100,7 +100,7 @@ def PrepareData(image,z):
     return image_loaded_z
 
 
-def MaskZstack(masks_loaded,image,channel_names_loaded, mask_props=None, intensity_props=["mean_intensity"]):
+def MaskZstack(masks_loaded,image,channel_names_loaded, mask_props=None, intensity_props=["intensity_mean"]):
     """This function will extract the stats for each cell mask through each channel
     in the input image
 
@@ -154,10 +154,10 @@ def MaskZstack(masks_loaded,image,channel_names_loaded, mask_props=None, intensi
         mask_dict = {}
         # Mean intensity is default property, stored without suffix
         mask_dict.update(
-            zip(channel_names_loaded, [x["mean_intensity"] for x in dict_of_chan[nm]])
+            zip(channel_names_loaded, [x["intensity_mean"] for x in dict_of_chan[nm]])
         )
         # All other properties are suffixed with their names
-        for prop_n in set(dict_of_chan[nm][0].keys()).difference(["mean_intensity"]):
+        for prop_n in set(dict_of_chan[nm][0].keys()).difference(["intensity_mean"]):
             mask_dict.update(
                 zip([f"{n}_{prop_n}" for n in channel_names_loaded], [x[prop_n] for x in dict_of_chan[nm]])
             )
@@ -169,7 +169,7 @@ def MaskZstack(masks_loaded,image,channel_names_loaded, mask_props=None, intensi
     # Return the dict of dataframes for each mask
     return dict_of_chan
 
-def ExtractSingleCells(masks,image,channel_names,output, mask_props=None, intensity_props=["mean_intensity"]):
+def ExtractSingleCells(masks,image,channel_names,output, mask_props=None, intensity_props=["intensity_mean"]):
     """Function for extracting single cell information from input
     path containing single-cell masks, z_stack path, and channel_names path."""
 
@@ -243,7 +243,7 @@ def ExtractSingleCells(masks,image,channel_names,output, mask_props=None, intens
                             )
 
 
-def MultiExtractSingleCells(masks,image,channel_names,output, mask_props=None, intensity_props=["mean_intensity"]):
+def MultiExtractSingleCells(masks,image,channel_names,output, mask_props=None, intensity_props=["intensity_mean"]):
     """Function for iterating over a list of z_stacks and output locations to
     export single-cell data from image masks"""
 


### PR DESCRIPTION
* Fixed support for images in `.hdf5` format
* Changed `mean_intensity` to `intensity_mean` to be consistent with the latest version of [regionprops](https://scikit-image.org/docs/dev/api/skimage.measure.html#regionprops). Adjusted to `intensity_median` to match.
* Added a function that returns the number of channels in an image. Benchmarked the function against SARDANA-097 .ome.tif to ensure that it doesn't add significant runtime.
* Used the new function to verify that the number of entries in `markers.csv` matches the number of channels in the image.
* Adjusted loading of `markers.csv` such that it correctly parses `marker_name` in single-column files.

Closes #32 