### PR TITLE
Robust handling of filenames with dots (`.`) in them

### DIFF
--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -236,8 +236,12 @@ def ExtractSingleCells(masks,image,channel_names,output, mask_props=None, intens
     scdata_z = MaskZstack(masks_loaded,image,channel_names_loaded_checked, mask_props=mask_props, intensity_props=intensity_props)
     #Write the singe cell data to a csv file using the image name
 
+    # Determine the image name by cutting off its extension
     im_full_name = os.path.basename(image)
-    im_name = im_full_name.split('.')[0]
+    im_tokens = im_full_name.split(os.extsep)
+	if len(fileNamePrefix) < 2:       im_name = im_tokens[0]
+	elif fileNamePrefix[-2] == "ome": im_name = os.extsep.join(im_tokens[0:-2])
+	else:                             im_name = os.extsep.join(im_tokens[0:-1])
 
     # iterate through each mask and export csv with mask name as suffix
     for k,v in scdata_z.items():

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -239,9 +239,9 @@ def ExtractSingleCells(masks,image,channel_names,output, mask_props=None, intens
     # Determine the image name by cutting off its extension
     im_full_name = os.path.basename(image)
     im_tokens = im_full_name.split(os.extsep)
-	if len(fileNamePrefix) < 2:       im_name = im_tokens[0]
-	elif fileNamePrefix[-2] == "ome": im_name = os.extsep.join(im_tokens[0:-2])
-	else:                             im_name = os.extsep.join(im_tokens[0:-1])
+    if len(im_tokens) < 2: im_name = im_tokens[0]
+    elif im_tokens[-2] == "ome": im_name = os.extsep.join(im_tokens[0:-2])
+    else: im_name = os.extsep.join(im_tokens[0:-1])
 
     # iterate through each mask and export csv with mask name as suffix
     for k,v in scdata_z.items():


### PR DESCRIPTION
Previous version was defining the output filename to be the first token resulting from splitting the input image filename by dot `.`, which was creating issues for filenames that have periods in them. For example, processing the following files
```
11ah01522-1.8_slide0_ROI1.ome.tiff
11ah01522-1.8_slide0_ROI2.ome.tiff
11ah01522-1.8_slide0_ROI3.ome.tiff
```
would write the outputs for all three files to `11ah01522-1.csv`.

The new version resolves this collision by purposefully removing the extension of the input image filename and properly accounting for the `ome` suffix, if it exists.