### PR TITLE
Added function for summing intensity values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ Module for single-cell data extraction given a segmentation mask and multi-chann
     By default only mean intensity is calculated.
     If the metric doesn't depend on signal intensity, use `--mask-props` instead.
     See list at https://scikit-image.org/docs/dev/api/skimage.measure.html#regionprops
-    Additionally available is gini_index, which calculates a single number
+
+    Currently, the following additional properties can be specified:
+
+    * `--intensity_props gini_index` : The Gini index calculates a single number
     between 0 and 1, representing how unequal the signal is distributed in each region.
-    See https://en.wikipedia.org/wiki/Gini_coefficient. For example, to calculate the median intensity, specify `--intensity_props median_intensity`.
+    See https://en.wikipedia.org/wiki/Gini_coefficient for more information.
+    * `--intensity_props intensity_median` : Will calculate the median of intensity values per labeled object in the mask.
+    * `--intensity_props intensity_sum` : Will calculate the sum of intensity values per labelled object in the mask. This can be useful if you want to count RNA molecules from FISH based images for example.
 
 # Run script
 `python CommandSingleCellExtraction.py --masks ./segmentation/cellMask.tif ./segmentation/membraneMask.tif --image ./registration/Exemplar_001.h5  --output ./feature_extraction --channel_names ./my_channels.csv`
@@ -33,4 +38,3 @@ Denis Schapiro (https://github.com/DenisSch)
 Joshua Hess (https://github.com/JoshuaHess12)
 
 Jeremy Muhlich (https://github.com/jmuhlich)
-

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -12,19 +12,23 @@ import tifffile
 
 from pathlib import Path
 
-## Function to sum intensity values (or in this case transcript counts) using regionprops
-def intensity_sum(mask, intensity):
-        return np.sum(intensity[mask])
+#### Additional functions that can be specified by the user via intensity_props
 
+## Function to calculate median intensity values per mask 
+def intensity_median(mask, intensity):
+    return np.median(intensity[mask])
+
+## Function to sum intensity values (or in this case transcript counts)
+def intensity_sum(mask, intensity):
+    return np.sum(intensity[mask])
+
+## Function to calculate the gini index: https://en.wikipedia.org/wiki/Gini_coefficient
 def gini_index(mask, intensity):
     x = intensity[mask]
     sorted_x = np.sort(x)
     n = len(x)
     cumx = np.cumsum(sorted_x, dtype=float)
     return (n + 1 - 2 * np.sum(cumx) / cumx[-1]) / n
-
-def intensity_median(mask, intensity):
-    return np.median(intensity[mask])
 
 def MaskChannel(mask_loaded, image_loaded_z, intensity_props=["intensity_mean"]):
     """Function for quantifying a single channel image

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -13,7 +13,7 @@ import tifffile
 from pathlib import Path
 
 ## Function to sum intensity values (or in this case transcript counts) using regionprops
-def mask_sum(mask, intensity):
+def intensity_sum(mask, intensity):
         return np.sum(intensity[mask])
 
 def gini_index(mask, intensity):

--- a/SingleCellDataExtraction.py
+++ b/SingleCellDataExtraction.py
@@ -12,6 +12,9 @@ import tifffile
 
 from pathlib import Path
 
+## Function to sum intensity values (or in this case transcript counts) using regionprops
+def mask_sum(mask, intensity):
+        return np.sum(intensity[mask])
 
 def gini_index(mask, intensity):
     x = intensity[mask]


### PR DESCRIPTION
Simple PR that adds a function to perform summing of intensities per mask. 

User can activate summing by supplying ` --intensity_props mask_sum` to the `CommandSingleCellExtraction.py`. 